### PR TITLE
Fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Even if Log4brains is developed with TypeScript and is part of the NPM ecosystem
 For projects that do not have a `package.json` file, you have to install Log4brains globally:
 
 ```bash
-npm install -g @log4brains-cli @log4brains-web
+npm install -g @log4brains/cli @log4brains/web
 ```
 
 Create a `.log4brains.yml` file at the root of your project and [configure it](#how-to-configure-log4brainsyml).


### PR DESCRIPTION
When I try to install log4brains according to README.md, I get an error:

```terminal
$ npm install -g @log4brains-cli @log4brains-web
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "@log4brains-cli": Tags may not have any characters that encodeURIComponent encodes.
```

When I use `/` instead of `-`, it seems to work.

This is also in line with the command line shown at https://www.npmjs.com/package/@log4brains/cli

![image](https://user-images.githubusercontent.com/1366654/102872356-de693f80-443f-11eb-9188-89e50abf2dbe.png)
