### PR TITLE
fix(init): Typo in ADR template link

### DIFF
--- a/packages/init/assets/template.md
+++ b/packages/init/assets/template.md
@@ -69,5 +69,5 @@ Chosen option: "[option 1]", because [justification. e.g., only option, which me
 
 ## Links <!-- optional -->
 
-- [Link type][link to adr] <!-- example: Refined by [xxx](yyyymmdd-xxx.md) -->
+- [Link type](link to adr) <!-- example: Refined by [xxx](yyyymmdd-xxx.md) -->
 - … <!-- numbers of links can vary -->


### PR DESCRIPTION
Very minor fixed, but I noticed that the default template had a broken markdown link.