### PR TITLE
Two initialization message improvements

### DIFF
--- a/packages/init/src/commands/InitCommand.ts
+++ b/packages/init/src/commands/InitCommand.ts
@@ -193,7 +193,7 @@ export class InitCommand {
           (answer) => !!answer.trim()
         );
         const pkgCodeFolder = await this.askPathWhileNotFound(
-          "Where is located the source code of this package?",
+          "Where is the source code of this package located?",
           cwd,
           `./packages/${pkgName}`
         );

--- a/packages/init/src/commands/InitCommand.ts
+++ b/packages/init/src/commands/InitCommand.ts
@@ -362,7 +362,7 @@ export class InitCommand {
     await this.copyFileIfAbsent(cwd, adrFolder, "README.md");
 
     // List existing ADRs
-    this.console.updateSpinner("Creating your first ADR...");
+    this.console.updateSpinner("Creating your first ADRs...");
     const adrListRes = await execa("log4brains", ["adr", "list", "--raw"], {
       cwd
     });


### PR DESCRIPTION
Thanks so much for creating this tool, this is a piece of outstanding work!

However, after having done some testing and running the `log4brains init` a second time today, it knew that the message `Creating your first ADR` was lying straight to my face :wink:  → 811311a595d407bba58c4ee3369dcdfd0cb4c6cf

Also during my first test i came across a phrasing that felt a bit quirky to me, therefore i suggest the following fix → eab387d3da5311967ce8a62748979c724f23fe56