### PR TITLE
feat: add log4brains adr list by tag in cli

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -112,6 +112,7 @@ export function createCli({ appConsole }: Deps): commander.Command {
       "Filter on the given statuses, comma-separated"
     ) // TODO: list available statuses
     .option("-r, --raw", "Use a raw format instead of a table", false)
+    .option("-t, --tags <tags>", "Filter on the given tags, comma-separated")
     .description("List ADRs")
     .action(
       (opts: ListCommandOpts): Promise<void> => {

--- a/packages/cli/src/commands/ListCommand.ts
+++ b/packages/cli/src/commands/ListCommand.ts
@@ -8,6 +8,7 @@ type Deps = {
 
 export type ListCommandOpts = {
   statuses: string;
+  tags: string;
   raw: boolean;
 };
 
@@ -25,6 +26,9 @@ export class ListCommand {
     const filters: SearchAdrsFilters = {};
     if (opts.statuses) {
       filters.statuses = opts.statuses.split(",") as AdrDtoStatus[];
+    }
+    if (opts.tags) {
+      filters.tags = opts.tags.split(",");
     }
     const adrs = await this.l4bInstance.searchAdrs(filters);
     const table = this.console.createTable({

--- a/packages/core/src/adr/application/queries/SearchAdrsQuery.ts
+++ b/packages/core/src/adr/application/queries/SearchAdrsQuery.ts
@@ -3,6 +3,7 @@ import { Query } from "@src/application";
 
 export type SearchAdrsFilters = {
   statuses?: AdrStatus[];
+  tags?: string[];
 };
 
 export class SearchAdrsQuery extends Query {

--- a/packages/core/src/adr/application/query-handlers/SearchAdrsQueryHandler.ts
+++ b/packages/core/src/adr/application/query-handlers/SearchAdrsQueryHandler.ts
@@ -25,6 +25,16 @@ export class SearchAdrsQueryHandler implements QueryHandler {
       ) {
         return false;
       }
+      else if ( query.filters.tags )
+      {
+        for (var i in query.filters.tags){
+          var tag = query.filters.tags[i];
+          if (adr.tags.includes(tag)) {
+            return true;
+          }
+        }
+        return false;
+      }
       return true;
     });
   }

--- a/packages/core/src/adr/application/query-handlers/SearchAdrsQueryHandler.ts
+++ b/packages/core/src/adr/application/query-handlers/SearchAdrsQueryHandler.ts
@@ -25,15 +25,10 @@ export class SearchAdrsQueryHandler implements QueryHandler {
       ) {
         return false;
       }
-      else if ( query.filters.tags )
-      {
-        for (var i in query.filters.tags){
-          var tag = query.filters.tags[i];
-          if (adr.tags.includes(tag)) {
-            return true;
-          }
-        }
-        return false;
+      if (query.filters.tags) {
+        return query.filters.tags.some((tag) => {
+          return adr.tags.includes(tag);
+        });
       }
       return true;
     });

--- a/packages/core/src/infrastructure/api/Log4brains.ts
+++ b/packages/core/src/infrastructure/api/Log4brains.ts
@@ -23,6 +23,7 @@ import { FileWatcher } from "../file-watcher";
 
 export type SearchAdrsFilters = {
   statuses?: AdrDtoStatus[];
+  tags?: string[];
 };
 
 /**
@@ -70,6 +71,9 @@ export class Log4brains {
       appFilters.statuses = filters.statuses.map((status) =>
         AdrStatus.createFromName(status)
       );
+    }
+    if (filters?.tags) {
+      appFilters.tags = filters.tags;
     }
     const adrs = await this.queryBus.dispatch<Adr[]>(
       new SearchAdrsQuery(appFilters)


### PR DESCRIPTION
Adding the option to run `log4brains adr list -t <tagname>` to be able to list ADRs by the given list of tags