### PR TITLE
feat(Core): Added support to ignore inline HTML comments in metadata header

### DIFF
--- a/packages/core/src/adr/domain/Adr.ts
+++ b/packages/core/src/adr/domain/Adr.ts
@@ -151,7 +151,7 @@ export class Adr extends AggregateRoot<Props> {
     if (
       !tags ||
       tags.trim() === "" ||
-      tags === "[space and/or comma separated list of tags] <!-- optional -->"
+      tags === "[space and/or comma separated list of tags]"
     ) {
       return [];
     }
@@ -163,7 +163,7 @@ export class Adr extends AggregateRoot<Props> {
     if (
       !deciders ||
       deciders.trim() === "" ||
-      deciders === "[list everyone involved in the decision] <!-- optional -->"
+      deciders === "[list everyone involved in the decision]"
     ) {
       return [];
     }

--- a/packages/core/src/adr/domain/MarkdownBody.test.ts
+++ b/packages/core/src/adr/domain/MarkdownBody.test.ts
@@ -106,6 +106,25 @@ Technical Story: [description | ticket/issue URL] <!-- optional -->
       );
       expect(body.getHeaderMetadata("Deciders")).toBeUndefined();
     });
+
+    it("ignores inline comments", () => {
+      const body = new MarkdownBody(
+        `# Hello World
+
+- Lorem Ipsum
+- Status: proposed <!-- [draft | proposed | rejected | accepted | deprecated | … | superseded by [xxx](yyyymmdd-xxx.md)] -->
+- DATE :   2020-01-01
+- Tags: test, blah <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+## Subtitle
+## Subtitle
+# Second title`
+      );
+      expect(body.getHeaderMetadata("status")).toEqual("proposed");
+      expect(body.getHeaderMetadata("date")).toEqual("2020-01-01");
+      expect(body.getHeaderMetadata("tags")).toEqual("test, blah");
+    });
   });
 
   describe("setHeaderMetadata()", () => {

--- a/packages/core/src/adr/domain/MarkdownBody.ts
+++ b/packages/core/src/adr/domain/MarkdownBody.ts
@@ -82,7 +82,7 @@ export class MarkdownBody extends Entity<Props> {
     if (!ul) {
       return undefined;
     }
-    const regexp = new RegExp(`^(\\s*${key}\\s*:\\s*)(.*)$`, "i");
+    const regexp = new RegExp(`^(\\s*${key}\\s*:\\s*)(.*?)(<!--.*-->)?$`, "i");
     const result = ul
       .children()
       .map((i, li) => {


### PR DESCRIPTION
Right now if you don't remove all of the comments in the metadata headers, it either includes them (in the tags) or keeps the ADR in a draft status (for the status).  By updating the RegEx that parses the meta data to find those inline HTML comments, we can keep other information available in the source of the ADR, but not display it in the browser.