### PR TITLE
fix: workaround for ERR_OSSL_EVP_UNSUPPORTED build issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Thank you so much! :clap:
 npm uninstall -g log4brains
 yarn install
 yarn link-cli
+yarn build
 
 yarn dev
 # ... if it does not work, you may have to add this line to your ~/.bashrc (or similar):

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "packages/**"
   ],
   "scripts": {
-    "dev": "lerna run --parallel dev",
-    "build": "lerna run --stream build",
+    "dev": "export NODE_OPTIONS=--openssl-legacy-provider && lerna run --parallel dev",
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider && lerna run --stream build",
     "clean": "lerna run clean",
     "typescript": "lerna run --stream typescript",
     "test": "lerna run --stream test",


### PR DESCRIPTION
This is a workaround to fix https://github.com/thomvaill/log4brains/issues/85 following this article https://medium.com/@sahilali/resolving-error-0308010c-digital-envelope-routines-unsupported-in-node-js-v19-9-0-2114021209cb

Tested locally on Mac with Node 21.5.0 and npm 10.2.4.

Before changes it was returning 
```
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:68:19)
    at Object.createHash (node:crypto:138:10)
```
on ```yarn build``` and ```yarn dev```

After changes it compiles well 