### PR TITLE
Update workflow to use self-hosted runners

### DIFF
--- a/.github/workflows/post-release-docker-hub.yml
+++ b/.github/workflows/post-release-docker-hub.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We have optimized GitHub Runners to enhance resource utilization and efficiency by reducing the default packages loaded by runners. Introducing new runner groups for better customization and performance

For more information checkout @https://betssongroup.atlassian.net/wiki/spaces/TTM/pages/428605820/Transition+repositories+to+new+dedicated+runner+group